### PR TITLE
Prep for v0.4.2

### DIFF
--- a/SourceTextParser.php
+++ b/SourceTextParser.php
@@ -18,7 +18,7 @@ class SourceTextParser{
 
 
 	// Establish the version of the library
-	const version = '0.3';
+	const version = '0.4.2';
 
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
     "require-dev": {
         "phpunit/phpunit": ">=4.8.35"
     },
+    "replace": {
+        "urbanmonastics/sourceparser": "*"
+    },
     "autoload": {
         "psr-4": {"UrbanMonastics\\SourceTextParser\\": ""},
         "exclude-from-classmap": [


### PR DESCRIPTION
This should help ensure projects are kept current with the naming
change (all of the old names should shift to this new project).