### PR TITLE
V1.0 Is ready!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 *.DS_Store
 cache.json
 .phpunit.result.cache
+index.php

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 vendor/
 *.DS_Store
 cache.json
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,13 @@ language: php
 
 matrix:
   include:
-    - php: 7.0
-      dist: xenial
-    - php: 7.1
+    - php: 8.1
       dist: bionic
-    - php: 7.2
+    - php: 8.2
       dist: bionic
-    - php: 7.3
+    - php: 8.3
       dist: bionic
-    - php: 7.4
-      dist: bionic
-    - php: 8.0
+    - php: 8.4
       dist: bionic
 
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM richarvey/nginx-php-fpm:1.10.3
+FROM richarvey/nginx-php-fpm:3.1.6
 
 COPY . .
 
@@ -11,8 +11,5 @@ ENV REAL_IP_HEADER 1
 
 # Allow composer to run as root
 ENV COMPOSER_ALLOW_SUPERUSER 1
-
-# Update composer to version 2.x
-RUN composer selfupdate --2
 
 CMD ["/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,7 @@ ENV REAL_IP_HEADER 1
 # Allow composer to run as root
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
+# Update composer to version 2.x
+RUN composer selfupdate --2
+
 CMD ["/start.sh"]

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ These texts may need to be used in various formats and contexts. There are going
 *	**setSelahHTML( *bool*, *string SelahTerm* )** default: false, selah  
 	Do we wrap the term Selah in html for easier styling. The Selah term is optional, and allows you to indicated terms used in other languages.  
 *	**setSmallCapsText( *string* )**
-	Will look for the given word with every character capitalized. These words will then be wrapped in HTML for converting to small caps. This is done in some biblical texts to indicate when the tetragrammaton term "יְהֹוָה" (or yhwh) is used to reference God.  
+	Will look for the given word (case insensitive) with every character capitalized. These words will then be wrapped in HTML for converting to small caps. This is done in some biblical texts to indicate when the tetragrammaton term "יְהֹוָה" (or yhwh) is used to reference God.  
 *	**setSuppressAlleluia( *bool*, *string AlleluiaTerm* )** default: false, Alleluia  
 	During the season of Lent the use of the word Alleluia is suppressed. Enabling this option will remove any line where the only text is the word Alleluia. You may also define the alleluia term to look for in the texts for broader language support.  
 *	**setTitlesEnabled( *bool* )** default: false  

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ These texts may need to be used in various formats and contexts. There are going
 *	**setSelahHTML( *bool*, *string SelahTerm* )** default: false, selah  
 	Do we wrap the term Selah in html for easier styling. The Selah term is optional, and allows you to indicated terms used in other languages.  
 *	**setSmallCapsText( *string* )**
-	Will look for the given word with every character capitalized. These words will then be wrapped in HTML for converting to small caps. This is done in some biblical texts to indicate when the term "יְהֹוָה" (or yhwh) is used to reference God.  
+	Will look for the given word with every character capitalized. These words will then be wrapped in HTML for converting to small caps. This is done in some biblical texts to indicate when the tetragrammaton term "יְהֹוָה" (or yhwh) is used to reference God.  
 *	**setSuppressAlleluia( *bool*, *string AlleluiaTerm* )** default: false, Alleluia  
 	During the season of Lent the use of the word Alleluia is suppressed. Enabling this option will remove any line where the only text is the word Alleluia. You may also define the alleluia term to look for in the texts for broader language support.  
 *	**setTitlesEnabled( *bool* )** default: false  

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ These texts may need to be used in various formats and contexts. There are going
 	Do we place liturgical markers within HTML tags, or just place them directly into the document.
 *	**setSelahHTML( *bool*, *string SelahTerm* )** default: false, selah  
 	Do we wrap the term Selah in html for easier styling. The Selah term is optional, and allows you to indicated terms used in other languages.  
-*	**setSmallCapsText( *bool* )**
-	Will look for any words of three characters or longer with every character capitolized. These words will then be wrapped in HTML for converting to small caps. This is done in some biblical texts to indicate when the term "יְהֹוָה" (or yhwh) is used to reference God.  
+*	**setSmallCapsText( *string* )**
+	Will look for the given word with every character capitalized. These words will then be wrapped in HTML for converting to small caps. This is done in some biblical texts to indicate when the term "יְהֹוָה" (or yhwh) is used to reference God.  
 *	**setSuppressAlleluia( *bool*, *string AlleluiaTerm* )** default: false, Alleluia  
 	During the season of Lent the use of the word Alleluia is suppressed. Enabling this option will remove any line where the only text is the word Alleluia. You may also define the alleluia term to look for in the texts for broader language support.  
 *	**setTitlesEnabled( *bool* )** default: false  

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ These texts may need to be used in various formats and contexts. There are going
 	When enabled it will convert inline URL strings into clickable links.
 *	**setPreserveIndentations( *bool* )** default: false  
 	When enabled this will convert any tabs (set of 4 spaces) into four double spaces wrapped in a span. Enabling this will disable tabbing for code blocks.
+*	**setWrapLines( *bool* )** default: false  
+	When enabled this will wrap every line in a `div` tag, including classes for `paragraph-start`, `paragraph-end` and `indent`. Can be helpful when rendering poetry and scripture.
 *	**setLiturgicalElements( *bool* )** default: true  
 	When enabled the standard Markdown will be supplemented with liturgical elements. See Extending Markdown above for additions
 *	**setLiturgicalHTML( *bool* )** default: true  

--- a/README.md
+++ b/README.md
@@ -159,5 +159,20 @@ To make it easier to develop and build out the SourceTextParser we have setup a 
 
 In addition we have linked the NGNIX access and error logs to files in the docker directory. This can prove helpful when trouble shooting.
 
-	docker/nginx/access.log
-	docker/nginx/error.log
+You can make a simple `index.php` file and access it at http://localhost:8080/
+
+### A Sample index.php
+
+```php
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+$SourceTextParser = new UrbanMonastics\SourceTextParser\SourceTextParser();
+$SourceTextParser->setBreaksEnabled( true );
+
+$input = file_get_contents( __DIR__ . '/test/data/SOURCE_FILE.md' );
+echo $SourceTextParser->text($input);
+exit();
+
+?>
+```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The source texts use a subset of the Markdown functionality, and include some ad
 *	Including inline red letter text.  
 *	Supports overlined text for more robust manuscript support.  
 *	[GitHub flavored](https://github.github.com/gfm)  
-*	[Tested](http://parsedown.org/tests/) in 7.0 to 8.0
+*	[Tested](http://parsedown.org/tests/) in 8.1 to 8.4
 
 ## Extending Markdown  
 To ensure that we can support additional elements. These extensions are broken into inline or block level markings.

--- a/SourceTextParser.php
+++ b/SourceTextParser.php
@@ -1645,7 +1645,7 @@ class SourceTextParser{
 		// [V] or [R] 
 		if (preg_match('/^\[[V|R]\]/', $Line['text'], $matches)){
 			$element = $matches[0];
-			$this->responsoryResponse = array('PreviousLine' => NULL, 'ResponseNode' => NULL);
+			$this->responsoryResponse = array('PreviousLine' => NULL, 'FinalResponse' => NULL, 'MiddleResponse' => NULL);
 
 			if( stripos( $element, 'V') !== false ){
 				$Type = 'versicle';
@@ -1698,10 +1698,16 @@ class SourceTextParser{
 					),
 			);
 
-
 			$this->responsoryResponse['PreviousLine'] = $Type;
-			if( $Type == 'response' )
-				$this->responsoryResponse['ResponseNode'] = $TempNode;
+			if( $Type == 'response' ){
+				$this->responsoryResponse['FinalResponse'] = $TempNode;
+
+
+				if( $TempNode ){
+					$this->responsoryResponse['MiddleResponse'] = 'ZYS';
+				}
+			}
+
 
 			return $Block;
 		}
@@ -1719,9 +1725,11 @@ class SourceTextParser{
 
 
 			// Place the Response before this line if it was not included previously
-			if( !is_null( $this->responsoryResponse['ResponseNode'] ) && $Type == 'versicle' && $this->responsoryResponse['PreviousLine'] == 'versicle'){
-				
-				$CurrentBlock['element']['elements'][] = $this->responsoryResponse['ResponseNode'];
+			if( !is_null( $this->responsoryResponse['FinalResponse'] ) && $Type == 'versicle' && $this->responsoryResponse['PreviousLine'] == 'versicle'){
+				if( !is_null( $this->responsoryResponse['MiddleResponse'] ))
+					$CurrentBlock['element']['elements'][] = $this->responsoryResponse['MiddleResponse'];
+				else
+					$CurrentBlock['element']['elements'][] = $this->responsoryResponse['FinalResponse'];
 			}
 
 
@@ -1754,10 +1762,17 @@ class SourceTextParser{
 					),
 			);
 
-
 			$this->responsoryResponse['PreviousLine'] = $Type;
-			if( $Type == 'response' )
-				$this->responsoryResponse['ResponseNode'] = $TempNode;
+			if( $Type == 'response' ){
+				$this->responsoryResponse['FinalResponse'] = $TempNode;
+
+				if( strpos( $Text, '[*]') !== false ){
+					$TempNode['elements'][1]['handler']['argument'] = '  ' . trim( substr( $Text, strpos( $Text, '[*]') + 3 ) );
+					$this->responsoryResponse['MiddleResponse'] = $TempNode;
+				}
+
+				
+			}
 
 			return $CurrentBlock;
 		}
@@ -1766,8 +1781,8 @@ class SourceTextParser{
 
 	protected function blockLiturgicalResponseComplete(array $CurrentBlock){
 		// Remove the trailing <br> from the non-HTML version
-		if( !is_null( $this->responsoryResponse['ResponseNode'] ) && $this->responsoryResponse['PreviousLine'] == 'versicle'){
-			$CurrentBlock['element']['elements'][] = $this->responsoryResponse['ResponseNode'];
+		if( !is_null( $this->responsoryResponse['FinalResponse'] ) && $this->responsoryResponse['PreviousLine'] == 'versicle'){
+			$CurrentBlock['element']['elements'][] = $this->responsoryResponse['FinalResponse'];
 		}
 
 		return $CurrentBlock;

--- a/SourceTextParser.php
+++ b/SourceTextParser.php
@@ -15,10 +15,8 @@
 namespace UrbanMonastics\SourceTextParser;
 
 class SourceTextParser{
-
-
 	// Establish the version of the library
-	const version = '0.4.4';
+	const version = '1.0';
 
 
 	/**

--- a/SourceTextParser.php
+++ b/SourceTextParser.php
@@ -217,10 +217,10 @@ class SourceTextParser{
 		return $this;
 	}
 
-	public function setSuppressAlleluia(bool $suppressAlleluia, string $AlleluiaTerm = NULL ){
+	public function setSuppressAlleluia(bool $suppressAlleluia, string $AlleluiaTerm ){
 		$this->suppressAlleluia = $suppressAlleluia;
 
-		if( !is_null( $AlleluiaTerm ) )
+		if( !empty( $AlleluiaTerm ) )
 			$this->AlleluiaTerm = $AlleluiaTerm;
 
 		return $this;
@@ -232,10 +232,10 @@ class SourceTextParser{
 		return $this;
 	}
 
-	public function setSelahHTML(bool $selahHTML, string $SelahTerm = NULL ){
+	public function setSelahHTML(bool $selahHTML, string $SelahTerm ){
 		$this->selahHTML = $selahHTML;
 
-		if( !is_null( $SelahTerm ) )
+		if( !empty( $SelahTerm ) )
 			$this->SelahTerm = $SelahTerm;
 
 		return $this;

--- a/SourceTextParser.php
+++ b/SourceTextParser.php
@@ -64,7 +64,8 @@ class SourceTextParser{
 	protected $liturgicalHTML = true;	// Do we wrap liturgical elements in HTML tags
 	protected $suppressAlleluia = false;	// Do we remove the word Alleluia from the text
 	protected $AlleluiaTerm = 'Alleluia';	// What word do we look for as Alleluia
-	protected $smallCapsText = false;	// Do we convert all caps words into small caps words?
+	protected $smallCapsText = '';	// Do we convert all caps words into small caps words?
+	protected $SmallCapMarkers = array();	// Holds the preg_match output for Small Caps Texts
 	protected $selahHTML = false;	// Do we wrap selah in HTML for fancy rendering
 	protected $SelahTerm = 'Selah';	// What word do we look for as Selah
 
@@ -218,8 +219,8 @@ class SourceTextParser{
 		return $this;
 	}
 
-	public function setSmallCapsText(bool $smallCapsText){
-		$this->smallCapsText = $smallCapsText;
+	public function setSmallCapsText(string $smallCapsText){
+		$this->smallCapsText = strtoupper( $smallCapsText );
 
 		return $this;
 	}
@@ -1217,7 +1218,8 @@ class SourceTextParser{
 		if( !isset( $this->SmallCapMarkers )){
 			$this->SmallCapMarkers = array();
 		}
-		if( $this->smallCapsText && preg_match('/\b[A-Z]{3,}\b/', $text, $SmallCapsMatches ) ){
+
+		if( !empty( $this->smallCapsText ) && preg_match('/\b'. $this->smallCapsText .'\b/', $text, $SmallCapsMatches ) ){
 			$SmallCapsMatches = array_unique( $SmallCapsMatches );
 
 			foreach( $SmallCapsMatches as $aMatch ){
@@ -1243,7 +1245,7 @@ class SourceTextParser{
 				&& strtolower( mb_substr( $excerpt, 0, strlen( $this->AlleluiaTerm ) ) ) == strtolower( $this->AlleluiaTerm ) ){
 				$marker = 'alleluia';
 			}
-			else if( $this->smallCapsText && in_array( $marker, $this->SmallCapMarkers ) ){
+			else if( !empty( $this->smallCapsText ) && in_array( $marker, $this->SmallCapMarkers ) ){
 				$marker = 'smallcaps';
 			}
 
@@ -2100,7 +2102,7 @@ class SourceTextParser{
 	}
 
 	protected function inlineLiturgicalSmallCaps( $Excerpt ){
-		if( !$this->smallCapsText ){
+		if( empty( $this->smallCapsText ) ){
 			return;	// Small Caps is disabled matches found
 		}
 

--- a/SourceTextParser.php
+++ b/SourceTextParser.php
@@ -59,7 +59,8 @@ class SourceTextParser{
 	protected $urlsLinked = true;		// Convert any URL into a link
 	protected $safeMode = false;	// How strict are we about raw HTML code
 	protected $strictMode;
-	protected $preserveIndentations = false;	// Do we add spacers to perserve indentations
+	protected $preserveIndentations = false;	// Do we add spacers to preserve indentations
+	protected $wrapLines = false;	// Do we wrap every line in a Div with supporting class attributes?
 	protected $liturgicalElements = true;	// Look for liturgical elements in the text
 	protected $liturgicalHTML = true;	// Do we wrap liturgical elements in HTML tags
 	protected $suppressAlleluia = false;	// Do we remove the word Alleluia from the text
@@ -198,6 +199,12 @@ class SourceTextParser{
 		return $this;
 	}
 
+	public function setWrapLines( bool $wrapLines ){
+		$this->wrapLines = $wrapLines;
+
+		return $this;
+	}
+
 	public function setLiturgicalElements(bool $liturgicalElements){
 		$this->liturgicalElements = $liturgicalElements;
 
@@ -332,6 +339,10 @@ class SourceTextParser{
 					if( $tabs >= 2 && $this->liturgicalHTML ){
 						$text = '<span class="spacer-tab-x2">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>' . $text;
 						$tabs = $tabs - 2;
+
+						if( $this->wrapLines ){
+							$text = '/t' . $text;	// Adding this back so we can properly style this line later
+						}
 					}else{
 						if( $this->liturgicalHTML )
 							$text = '<span class="spacer-tab">&nbsp;&nbsp;&nbsp;&nbsp;</span>' . $text;
@@ -339,6 +350,10 @@ class SourceTextParser{
 							$text = '&nbsp;&nbsp;&nbsp;&nbsp;' . $text;
 
 						--$tabs;
+					}
+
+					if( $this->wrapLines ){
+						$text = '/t' . $text;	// Adding this back so we can properly style this line later
 					}
 				}
 				while( $tabs > 0 );
@@ -450,6 +465,46 @@ class SourceTextParser{
 		}
 
 		# ~
+
+
+		/*
+		* Re-wrap text in Div tags
+		*/
+		if( $this->wrapLines ){
+			$CurrentElements = $Elements;
+			$Elements = array();
+			foreach( $CurrentElements as $paragraph ){
+				$lines = explode("\n", $paragraph['handler']['argument'] );
+				foreach( $lines as $i => $line ){
+					$lineClass = $lineAttributes = array();
+					if ( $i == 0 )
+						$lineClass[] = 'paragraph-start';
+					if( $i+1 == count( $lines ) )	
+						$lineClass[] = 'paragraph-end';
+
+					if( stripos( $line, '/t/t' ) === 0 ){
+						$line = substr( $line, 4 );
+						$lineClass[] = 'indent-x2';
+					}
+					if( stripos( $line, '/t' ) === 0 ){
+						$line = substr( $line, 2 );
+						$lineClass[] = 'indent';
+					}
+
+					if( !empty( $lineClass ) )
+					$lineAttributes = array('class' => implode(' ', $lineClass));
+
+					$Elements[] = array('name' => 'div',
+									'attributes' => $lineAttributes,
+									'handler' => array(
+										'function' => 'lineElements',
+										'destination' => 'elements',
+										'argument' => $line
+									)
+								);
+				} // End: foreach($lines)
+			} // End: foreach($CurrentElements)
+		} // End: if($this->wrapLines)
 
 		return $Elements;
 	}

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.4",
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.8.35"
+        "phpunit/phpunit": "^6"
     },
     "replace": {
         "urbanmonastics/sourceparser": "*"

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6"
+        "phpunit/phpunit": "^11"
     },
     "replace": {
         "urbanmonastics/sourceparser": "*"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   nginx-php:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       - "8080:80"
     volumes:
       - ./:/var/www/html
-      - ./docker/nginx/error.log:/var/log/nginx/error.log
-      - ./docker/nginx/access.log:/var/log/nginx/access.log
+      # - ./docker/nginx/error.log:/var/log/nginx/error.log
+      # - ./docker/nginx/access.log:/var/log/nginx/access.log
       - ./../Source-Texts:/var/www/html/Source-Texts
     environment:
       APP_ENV: development

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,3 +2,12 @@
 
 # build our project
 docker compose build
+
+# start in the background
+docker-compose up -d
+
+# update composer
+docker exec -it sourcetextparser_nginx_php composer selfupdate --2
+
+# install composer libraries
+docker exec -it sourcetextparser_nginx_php composer install

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false">
+	<testsuites>
+        <testsuite name="urbanmonastics/sourcetextparser unit tests">
+			<file>test/SourTextParserTest.php</file>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/test/SourceTextParserTest.php
+++ b/test/SourceTextParserTest.php
@@ -62,7 +62,9 @@ class SourceTextParserTest extends TestCase
 		if( stripos( $test, 'selah_termed' ) !== false ){
 	        $this->SourceTextParser->setSelahHTML( true, 'OtherSelah'  );
 		}
-        $this->SourceTextParser->setSmallCapsText( stripos( $test, 'small_caps' ) !== false );
+        if( stripos( $test, 'small_caps' ) !== false  ){
+            $this->SourceTextParser->setSmallCapsText('lord');
+        }
         $this->SourceTextParser->setSuppressAlleluia( stripos( $test, 'supress_alleluia' ) !== false, 'Alleluia' );
 		if( stripos( $test, 'supress_alleluia_termed' ) !== false ){
 	        $this->SourceTextParser->setSuppressAlleluia( stripos( $test, 'supress_alleluia' ) !== false, 'OtherAlleluia' );

--- a/test/SourceTextParserTest.php
+++ b/test/SourceTextParserTest.php
@@ -7,26 +7,16 @@ use UrbanMonastics\SourceTextParser\SourceTextParser as SourceTextParser;
 
 class SourceTextParserTest extends TestCase
 {
+    protected $SourceTextParser;
+
+
     final function __construct($name = null, array $data = array(), $dataName = '')
     {
-        $this->dirs = $this->initDirs();
         $this->SourceTextParser = $this->initSourceTextParser();
 
         parent::__construct($name, $data, $dataName);
     }
 
-    private $dirs;
-    protected $SourceTextParser;
-
-    /**
-     * @return array
-     */
-    protected function initDirs()
-    {
-        $dirs []= dirname(__FILE__).'/data/';
-
-        return $dirs;
-    }
 
     /**
      * @return SourceTextParser
@@ -114,11 +104,12 @@ class SourceTextParserTest extends TestCase
         $this->assertEquals($expectedSafeMarkup, $actualSafeMarkup);
     }
 
-    function data()
+    public static function data()
     {
         $data = array();
+        $dirs = array(dirname(__FILE__).'/data/');
 
-        foreach ($this->dirs as $dir)
+        foreach ($dirs as $dir)
         {
             $Folder = new DirectoryIterator($dir);
 

--- a/test/SourceTextParserTest.php
+++ b/test/SourceTextParserTest.php
@@ -63,11 +63,16 @@ class SourceTextParserTest extends TestCase
 	        $this->SourceTextParser->setSelahHTML( true, 'OtherSelah'  );
 		}
         if( stripos( $test, 'small_caps' ) !== false  ){
-            $this->SourceTextParser->setSmallCapsText('lord');
+            $this->SourceTextParser->setSmallCapsText('lord');  // Case insensitive
         }
         $this->SourceTextParser->setSuppressAlleluia( stripos( $test, 'supress_alleluia' ) !== false, 'Alleluia' );
 		if( stripos( $test, 'supress_alleluia_termed' ) !== false ){
 	        $this->SourceTextParser->setSuppressAlleluia( stripos( $test, 'supress_alleluia' ) !== false, 'OtherAlleluia' );
+		}
+
+		if( stripos( $test, 'wrap_lines' ) !== false ){
+	        $this->SourceTextParser->setWrapLines( true );
+            $this->SourceTextParser->setPreserveIndentations( true );
 		}
 
         $actualMarkup = $this->SourceTextParser->text( $markdown );

--- a/test/data/liturgy_response.html
+++ b/test/data/liturgy_response.html
@@ -4,9 +4,9 @@
 <div class="response-response">
 <span class="symbol-response">&#8479;</span>  Great is our Lord, <span class="symbol-star"> *</span> and great is his power.</div>
 <div class="response-versicle">
-<span class="symbol-versicle">&#8483;</span>  And his wisdom is endless.</div>
+<span class="symbol-versicle">&#8483;</span>  And his wisdom is endless,</div>
 <div class="response-response">
-<span class="symbol-response">&#8479;</span>  Great is our Lord, <span class="symbol-star"> *</span> and great is his power.</div>
+<span class="symbol-response">&#8479;</span>  and great is his power.</div>
 <div class="response-versicle">
 <span class="symbol-versicle">&#8483;</span>  Glory to the Father, to the Son, and to the Holy Spirit.</div>
 <div class="response-response">

--- a/test/data/liturgy_response.md
+++ b/test/data/liturgy_response.md
@@ -1,4 +1,4 @@
 [V] Great is our Lord, and great is his power.
 [R] Great is our Lord, [*] and great is his power.
-[V] And his wisdom is endless.
+[V] And his wisdom is endless,
 [V] Glory to the Father, to the Son, and to the Holy Spirit.

--- a/test/data/liturgy_response_short.html
+++ b/test/data/liturgy_response_short.html
@@ -1,0 +1,6 @@
+<section class="response">
+<div class="response-versicle">
+<span class="symbol-versicle">&#8483;</span>  In following Your Testimonies, Lord, I rejoice.</div>
+<div class="response-response">
+<span class="symbol-response">&#8479;</span>  I will not forget your word.</div>
+</section>

--- a/test/data/liturgy_response_short.md
+++ b/test/data/liturgy_response_short.md
@@ -1,0 +1,2 @@
+[V] In following Your Testimonies, Lord, I rejoice.
+[R] I will not forget your word.

--- a/test/data/liturgy_small_caps.html
+++ b/test/data/liturgy_small_caps.html
@@ -8,4 +8,4 @@ Offer your righteous sacrifices, <span class="symbol-star"> *</span>
 and trust in the <span class="type-small-caps">LORD</span>.</p>
 <p>Many are asking, "Who can show us anything good?" <span class="symbol-star"> *</span>
 <span class="type-small-caps">LORD</span>, let the light of your face shine upon us!</p>
-<p>EXCLUde thESE wORDS</p>
+<p>EXCLUde this version of Lord and thESE wORDS</p>

--- a/test/data/liturgy_small_caps.md
+++ b/test/data/liturgy_small_caps.md
@@ -11,4 +11,4 @@ Offer your righteous sacrifices, [*]
 Many are asking, "Who can show us anything good?" [*]
 	LORD, let the light of your face shine upon us!
 
-EXCLUde thESE wORDS
+EXCLUde this version of Lord and thESE wORDS

--- a/test/data/liturgy_symbols.html
+++ b/test/data/liturgy_symbols.html
@@ -1,5 +1,5 @@
 <p>Lord, <span class="symbol-cross">&#10011;</span> open my lips.<span class="symbol-star"> *</span><br />
-And my mouth will declair your praise.</p>
+And my mouth will declare your praise.</p>
 <p>To this you were called,<span class="symbol-dagger"> &#8224;</span><br />
 because Christ suffered for you,<span class="symbol-star"> *</span><br />
 leaving us an example to follow, that we should walk in his steps.</p>

--- a/test/data/liturgy_symbols.md
+++ b/test/data/liturgy_symbols.md
@@ -1,5 +1,5 @@
 Lord, [+] open my lips.[*]  
-And my mouth will declair your praise.
+And my mouth will declare your praise.
 
 
 To this you were called,[t]  

--- a/test/data/liturgy_wrap_lines.html
+++ b/test/data/liturgy_wrap_lines.html
@@ -1,0 +1,11 @@
+<div class="paragraph-start">God, arrogant people are attacking me, <span class="symbol-dagger"> &#8224;</span></div>
+<div class="indent"><span class="spacer-tab">&nbsp;&nbsp;&nbsp;&nbsp;</span>these violent people want my life, <span class="symbol-star"> *</span></div>
+<div class="indent"><span class="spacer-tab">&nbsp;&nbsp;&nbsp;&nbsp;</span>and they have no desire for You.</div>
+<div>But You, Lord, are a compassionate and gracious God, <span class="symbol-star"> *</span></div>
+<div class="paragraph-end indent"><span class="spacer-tab">&nbsp;&nbsp;&nbsp;&nbsp;</span>slow to anger, and overflowing with mercy and faithfulness.</div>
+<div class="paragraph-start">Turn towards me and be gracious with me, <span class="symbol-dagger"> &#8224;</span></div>
+<div class="indent"><span class="spacer-tab">&nbsp;&nbsp;&nbsp;&nbsp;</span>grant Your strength to Your servant, <span class="symbol-star"> *</span></div>
+<div class="paragraph-end indent"><span class="spacer-tab">&nbsp;&nbsp;&nbsp;&nbsp;</span>and save my life, Your servant's child.</div>
+<div class="paragraph-start">Make me into a sign of Your goodness, <span class="symbol-dagger"> &#8224;</span></div>
+<div class="indent"><span class="spacer-tab">&nbsp;&nbsp;&nbsp;&nbsp;</span>upon seeing it those who hate me will be ashamed, <span class="symbol-star"> *</span></div>
+<div class="paragraph-end indent"><span class="spacer-tab">&nbsp;&nbsp;&nbsp;&nbsp;</span>because You, LORD, have helped and comforted me.</div>

--- a/test/data/liturgy_wrap_lines.md
+++ b/test/data/liturgy_wrap_lines.md
@@ -1,0 +1,13 @@
+God, arrogant people are attacking me, [t]
+	these violent people want my life, [*]
+	and they have no desire for You.
+But You, Lord, are a compassionate and gracious God, [*]
+	slow to anger, and overflowing with mercy and faithfulness.
+
+Turn towards me and be gracious with me, [t]
+	grant Your strength to Your servant, [*]
+	and save my life, Your servant's child.
+
+Make me into a sign of Your goodness, [t]
+	upon seeing it those who hate me will be ashamed, [*]
+	because You, LORD, have helped and comforted me.


### PR DESCRIPTION
This release makes the Source Text Parser feature complete! With this update the Source Text Parser has added:

- Support for PHP 8.1, 8.2, 8.3, 8.4 and up
- Updated PHPUnit to version 11
- Added support for Line Wrapping (`setWrapLines( true )`) that will wrap each line in its own div tag, and includes classes `.paragraph-start .paragraph-end .indent .indent-x2`
- Refactored `setSmallCapsText( 'lord' )` to receive text instead of a boolean value. This now looks for the exact term instead of any all-caps string longer than 3 chars to mark as AllCaps.
- Fixed a mistake in the Responsory formating where the middle responses included the portion before the midpoint.
- Updates to the ReadMe